### PR TITLE
fix: #267 Sync task's state on project change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### API changes
 
 - Remove project attributes on task relationships
+- Task's state is synced with its related project on `PATCH /api/tasks/:id`
+  (please refer to tasks API documentation to know more about it)
 
 ### Migration notes
 

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -2,7 +2,9 @@ class Api::TasksController < ApiController
 
   def update
     @task = current_task
-    @task.update! update_task_params
+    @task.assign_attributes update_task_params
+    @task.sync_state_with_project
+    @task.save!
   end
 
   def update_state

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -48,6 +48,16 @@ class Task < ApplicationRecord
     impacted_tasks
   end
 
+  def sync_state_with_project
+    if self.newed? && (self.project.nil? || self.project.started?)
+      self.state = :started
+      self.started_at = DateTime.now
+    elsif self.started? && self.project.present? && !self.project.started?
+      self.state = :newed
+      self.started_at = nil
+    end
+  end
+
 private
 
   def set_order_attribute

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -211,6 +211,14 @@ Parameters:
 | task.label       | string | Task's label            | yes      |
 | task.project\_id | number | Task's project relation | yes      |
 
+Note: depending on the given project, task's state can change:
+
+- if task's state was `newed`, it is changed to `started` if no project is
+  given or if project is `started`
+- if task's state was `started`, it is changed to `newed` if given project is
+  NOT `started`
+- state doesn't change in any other configuration
+
 Result format:
 
 | Name                                            | Type   | Description                              | Optional |

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -487,4 +487,118 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '#sync_state_with_project' do
+    before do
+      Timecop.freeze DateTime.new(2017)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context 'when task is newed' do
+      let(:task) { build :task, :newed }
+
+      context 'when there are no attached projects' do
+        it 'sets task state to started' do
+          task.project = nil
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('started')
+          expect(task.started_at).to eq(DateTime.now)
+        end
+      end
+
+      context 'when attached project is started' do
+        it 'sets task state to started' do
+          task.project = build(:project, :started)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('started')
+          expect(task.started_at).to eq(DateTime.now)
+        end
+      end
+
+      context 'when attached project is NOT started' do
+        it 'does not change task state' do
+          task.project = build(:project, :newed)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('newed')
+        end
+      end
+    end
+
+    context 'when task is started' do
+      let(:task) { build :task, :started }
+
+      context 'when there are no attached projects' do
+        it 'does not change task state' do
+          task.project = nil
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('started')
+        end
+      end
+
+      context 'when attached project is started' do
+        it 'does not change task state' do
+          task.project = build(:project, :started)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('started')
+        end
+      end
+
+      context 'when attached project is NOT started' do
+        it 'sets task state to newed' do
+          task.project = build(:project, :newed)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('newed')
+        end
+      end
+    end
+
+    context 'when task is in another state' do
+      let(:task) { build :task, :planned }
+
+      context 'when there are no attached projects' do
+        it 'does not change task state' do
+          task.project = nil
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('planned')
+        end
+      end
+
+      context 'when attached project is started' do
+        it 'does not change task state' do
+          task.project = build(:project, :started)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('planned')
+        end
+      end
+
+      context 'when attached project is NOT started' do
+        it 'does not change task state' do
+          task.project = build(:project, :newed)
+
+          task.sync_state_with_project
+
+          expect(task.state).to eq('planned')
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/tasks_request_spec.rb
+++ b/spec/requests/api/tasks_request_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Api::TasksController, type: :request do
 
   describe 'PATCH #update' do
     let(:token) { user.token }
-    let(:project) { create :project }
+    let(:project) { create :project, :started }
     let(:payload) { {
       task: {
         label: 'A new label for a task',
         project_id: project.id,
       },
     } }
-    let(:task) { create :task, label: 'My task', project: nil, user: user }
+    let(:task) { create :task, :newed, label: 'My task', project: nil, user: user }
 
     subject { patch api_task_path(task.id), params: payload,
                                             headers: { 'Authorization': token },
@@ -42,6 +42,11 @@ RSpec.describe Api::TasksController, type: :request do
       it 'saves the new task' do
         expect(task.reload.label).to eq('A new label for a task')
         expect(task.reload.project).to eq(project)
+      end
+
+      it 'changes task state to started' do
+        # To know more about state syncing, please have a look at Task#sync_state_with_project
+        expect(task.reload.state).to eq('started')
       end
     end
 


### PR DESCRIPTION
Closes #267 

Changes proposed in this pull request:

- Sync task's state on project id change
- Refactor with syncing on task creation
- Document the API change

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
