### PR TITLE
fix: #305 Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN apk add --no-cache \
       nodejs \
       postgresql-client \
       tzdata \
-  && npm install npm@5 -g \
+  && npm install npm@6 -g \
   && apk --update add --virtual build-dependencies \
       build-base \
       ruby-dev \
-      openssl-dev \
       postgresql-dev \
       libc-dev \
       linux-headers \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,11 +9,10 @@ RUN apk add --no-cache \
       nodejs \
       postgresql-client \
       tzdata \
-  && npm install npm@5 -g
+  && npm install npm@6 -g
 RUN apk --update add --virtual build-dependencies \
       build-base \
       ruby-dev \
-      openssl-dev \
       postgresql-dev \
       libc-dev \
       linux-headers \


### PR DESCRIPTION
Closes https://github.com/lessy-community/lessy/issues/305

Changes proposed in this pull request:

`openssl-dev` seems to not be needed anymore and was conflicting with
`libressl-dev` (dependency of `postgresql-dev`).

npm@5 was failing with `Error: write after end` error. It has been fixed
in npm@6 so we just upgrade.

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
