### PR TITLE
fix: #301 Fix race condition when setting task order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem 'administrate'
 gem 'flipper'
 gem 'flipper-active_record'
 
+# Provide a lock system for DB
+gem 'with_advisory_lock', '~> 3.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    with_advisory_lock (3.2.0)
+      activerecord (>= 3.2)
 
 PLATFORMS
   ruby
@@ -278,6 +280,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   timecop (~> 0.8)
   tzinfo-data
+  with_advisory_lock (~> 3.2)
 
 BUNDLED WITH
    1.16.1

--- a/app/controllers/api/users/tasks_controller.rb
+++ b/app/controllers/api/users/tasks_controller.rb
@@ -12,8 +12,11 @@ class Api::Users::TasksController < ApiController
   def create
     @task = current_user.tasks.new(create_task_params)
     @task.sync_state_with_project
-    @task.sync_order
-    @task.save!
+    lock_name = "sync_order_for_user_#{current_user.id}"
+    Task.with_advisory_lock(lock_name) do
+      @task.sync_order
+      @task.save!
+    end
 
     NotificationsChannel.broadcast_to(
       current_user,

--- a/app/controllers/api/users/tasks_controller.rb
+++ b/app/controllers/api/users/tasks_controller.rb
@@ -12,6 +12,7 @@ class Api::Users::TasksController < ApiController
   def create
     @task = current_user.tasks.new(create_task_params)
     @task.sync_state_with_project
+    @task.sync_order
     @task.save!
 
     NotificationsChannel.broadcast_to(

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe Task, type: :model do
   describe 'create!' do
     subject { Task.create! label: 'a task', state: 'planned', planned_count: 0, planned_at: DateTime.new(2017), user: user }
 
-    it 'sets order to 1 by default' do
-      Task.destroy_all
-      expect(subject.order).to eq 1
-    end
-
-    it "sets order by incrementing maximum users' tasks order by 1" do
-      create :task, order: 41, user: user
-      expect(subject.order).to eq 42
-    end
-
     it 'sets planned_count to 1 if planned_at is set' do
       expect(subject.planned_count).to eq 1
     end
@@ -598,6 +588,33 @@ RSpec.describe Task, type: :model do
 
           expect(task.state).to eq('planned')
         end
+      end
+    end
+  end
+
+  describe '#sync_order' do
+    let(:task) { create :task, user: user }
+
+    subject { task.sync_order }
+
+    context 'when there is no other task' do
+      before do
+        Task.destroy_all
+      end
+
+      it 'sets order to 1 by default' do
+        expect(subject.order).to eq 1
+      end
+    end
+
+    context 'when there is already other tasks for this user' do
+      before do
+        Task.destroy_all
+        create :task, order: 41, user: user
+      end
+
+      it 'sets order by incrementing maximum task order by 1' do
+        expect(subject.order).to eq 42
       end
     end
   end


### PR DESCRIPTION
Closes #301 

Changes proposed in this pull request:

- Provide with_advisory_lock gem 
- Make explicit the task order setting 
- Put sync_order and save within a lock

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
