### PR TITLE
add: #184 Add feature to resend activation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Provide `POST /api/users/password_resets` endpoint
 - Provide `POST /api/users/passwords` endpoint
+- Provide `POST /api/users/activation_emails` endpoint
 
 ## Aries 2018-08-27
 

--- a/app/controllers/api/users/activation_emails_controller.rb
+++ b/app/controllers/api/users/activation_emails_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Api::Users::ActivationEmailsController < ApiController
+  skip_before_action :require_login, only: [:create]
+  skip_before_action :require_tos_accepted, only: [:create]
+
+  def create
+    user = User.find_by!(find_user_params)
+    UserMailer.activation_needed_email(user).deliver_later if user.inactive?
+    head :no_content
+  end
+
+  private
+
+  def find_user_params
+    fetch_resource_params(:user, [:email])
+  end
+end

--- a/client/src/api/users.js
+++ b/client/src/api/users.js
@@ -5,6 +5,15 @@ export default {
     return post('/api/users', { email }, false)
   },
 
+  resendActivationEmail: (email) => {
+    const payload = {
+      user: {
+        email,
+      },
+    }
+    return post('/api/users/activation_emails', payload, false)
+  },
+
   activate: (token, username, password) => {
     const url = `/api/users/activations`
     const payload = {

--- a/client/src/components/dashboard/DashboardPage.vue
+++ b/client/src/components/dashboard/DashboardPage.vue
@@ -1,6 +1,19 @@
 <template>
   <app-page name="dashboard">
-    <p v-if="!user.activated" v-html="$t('dashboard.page.activationInstructions', { email: user.email })"></p>
+    <ly-card v-if="!user.activated">
+      <p v-html="$t('dashboard.page.activationInstructions', { email: user.email })"></p>
+      <ly-button
+        v-if="!activationEmailResent"
+        icon="envelope-o"
+        @click="resendActivationEmail"
+      >
+        {{ $t('dashboard.page.resendActivationInstructions') }}
+      </ly-button>
+      <p v-else class="text-success">
+        <ly-icon name="check"></ly-icon>
+        {{ $t('dashboard.page.resendActivationInstructionsDone') }}
+      </p>
+    </ly-card>
 
     <ly-section :title="$t('dashboard.page.projectsInProgress')">
       <project-card-deck :projects="projects"></project-card-deck>
@@ -51,6 +64,7 @@
       return {
         createTaskEnabled: false,
         plannedAt: moment().endOf('day'),
+        activationEmailResent: false,
       }
     },
 
@@ -60,6 +74,14 @@
         projects: 'projects/listInProgress',
         tasks: 'tasks/listForToday',
       }),
+    },
+
+    methods: {
+      resendActivationEmail () {
+        this.$store
+          .dispatch('users/resendActivationEmail', { email: this.user.email })
+          .then(() => { this.activationEmailResent = true })
+      },
     },
   }
 </script>

--- a/client/src/components/users/UserPasswordResetForm.vue
+++ b/client/src/components/users/UserPasswordResetForm.vue
@@ -36,9 +36,16 @@
 
     methods: {
       resetPassword () {
-        this.$store.dispatch('users/resetPassword', { email: this.email })
-                   .then(() => { this.$emit('success', this.email) })
-                   .catch(this.setFailureErrors)
+        this.$store
+          .dispatch('users/resetPassword', { email: this.email })
+          .then(() => { this.$emit('success', this.email) })
+          .catch((errors) => {
+            this.$emit('fail', {
+              errors: errors.data.errors,
+              email: this.email
+            })
+            this.setFailureErrors(errors)
+          })
       },
     },
   }

--- a/client/src/components/users/UserPasswordResetLayout.vue
+++ b/client/src/components/users/UserPasswordResetLayout.vue
@@ -4,15 +4,35 @@
     <app-page name="user-password-reset">
       <div class="app-page-user-password-reset-container">
         <h1>{{ $t('users.passwordResetLayout.title') }}</h1>
+
         <template v-if="sentTo">
           <p>
             {{ $t('users.passwordResetLayout.emailSentTo', { email: sentTo }) }}
           </p>
           <router-link to="/login">{{ $t('users.passwordResetLayout.login') }}</router-link>
         </template>
+
+        <template v-else-if="emailToActivate">
+          <p>{{ $t('users.passwordResetLayout.accountInactive') }}</p>
+          <ly-button
+            v-if="!activationEmailResent"
+            icon="envelope-o"
+            @click="resendActivationEmail"
+          >
+            {{ $t('users.passwordResetLayout.resendActivationInstructions') }}
+          </ly-button>
+          <p v-else class="text-success">
+            <ly-icon name="check"></ly-icon>
+            {{ $t('users.passwordResetLayout.resendActivationInstructionsDone') }}
+          </p>
+        </template>
+
         <template v-else>
           <p>{{ $t('users.passwordResetLayout.emailIntro') }}</p>
-          <user-password-reset-form @success="onFormSuccess"></user-password-reset-form>
+          <user-password-reset-form
+            @success="onFormSuccess"
+            @fail="onFormFail"
+          ></user-password-reset-form>
         </template>
       </div>
     </app-page>
@@ -32,12 +52,29 @@
     data () {
       return {
         sentTo: null,
+        emailToActivate: null,
+        activationEmailResent: false,
       }
     },
 
     methods: {
       onFormSuccess (email) {
         this.sentTo = email
+      },
+
+      onFormFail ({ errors, email }) {
+        const isUserInactive = errors.some((error) => error.code === 'user_inactive')
+        if (isUserInactive) {
+          this.emailToActivate = email
+        }
+      },
+
+      resendActivationEmail () {
+        this.$store
+          .dispatch('users/resendActivationEmail', {
+            email: this.emailToActivate,
+          })
+          .then(() => { this.activationEmailResent = true })
       },
     },
   }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -16,6 +16,8 @@ export default {
       createTask: 'Add tasks for today',
       or: 'or',
       projectsInProgress: 'Projects in progress',
+      resendActivationInstructions: 'Resend activation instructions',
+      resendActivationInstructionsDone: 'Done',
       tasksForToday: '{count} task for today | {count} tasks for today',
     },
   },

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -398,9 +398,12 @@ export default {
     },
 
     passwordResetLayout: {
+      accountInactive: 'You didn’t activate your account and so we can’t reset your password. Did you receive the email with the activation instructions?',
       emailIntro: 'Please enter the email address related to your account so we’ll send you a link to reset your password.',
       emailSentTo: 'We’ve just sent an email to {email} so you’ll be able to create a new password in a few minutes. If you receive no emails, please check your spams.',
       login: 'You remember your password?',
+      resendActivationInstructions: 'Resend activation instructions',
+      resendActivationInstructionsDone: 'Done',
       title: 'Reset your password',
     },
 

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -398,9 +398,12 @@ export default {
     },
 
     passwordResetLayout: {
+      accountInactive: 'Vous n’avez pas activé votre compte et nous ne pouvons pas réinitialiser votre mot de passe. Avez-vous bien reçu le mail contenant les instructions d’activation ?',
       emailIntro: 'Veuillez entrer l’adresse email de votre compte afin de vous envoyer un lien permettant de réinitialiser votre mot de passe.',
       emailSentTo: 'Nous venons de vous envoyer un lien à l’adresse {email} afin que vous puissiez vous définir un nouveau mot de passe. Si vous ne recevez pas d’email, veuillez vérifier vos spams.',
       login: 'Vous vous souvenez de votre mot de passe ?',
+      resendActivationInstructions: 'Renvoyer les instructions',
+      resendActivationInstructionsDone: 'Fait',
       title: 'Réinitialisez votre mot de passe',
     },
 

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -16,6 +16,8 @@ export default {
       createTask: 'Ajouter des tâches pour aujourd’hui',
       or: 'ou',
       projectsInProgress: 'Projets en cours',
+      resendActivationInstructions: 'Renvoyer les instructions',
+      resendActivationInstructionsDone: 'Fait',
       tasksForToday: '{count} tâche pour aujourd’hui | {count} tâches pour aujourd’hui',
     },
   },

--- a/client/src/store/modules/users.js
+++ b/client/src/store/modules/users.js
@@ -39,6 +39,10 @@ const actions = {
       })
   },
 
+  resendActivationEmail ({ commit }, { email }) {
+    return usersApi.resendActivationEmail(email)
+  },
+
   activate ({ commit }, { token, username, password }) {
     return usersApi.activate(token, username, password)
       .then((res) => {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :inline
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     namespace :users do
       resources :authorizations, only: [:create]
       resources :activations, only: [:create]
+      resources :activation_emails, only: [:create]
       resources :passwords, only: [:create]
       resources :password_resets, only: [:create]
     end

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -185,6 +185,37 @@ $ curl -H "Content-Type: application/json" \
 }
 ```
 
+## `POST /api/users/activation_emails`
+
+Resend an activation emails containing a token to create an account.
+
+**This endpoint doesn't require an `Authorization` header.**
+
+Parameters:
+
+| Name       | Type   | Description  | Optional |
+|------------|--------|--------------|----------|
+| user       | object |              |          |
+| user.email | string | User's email |          |
+
+Result format: none.
+
+Please note that if the account is already activated, the response will be
+positive but no emails are sent.
+
+Example:
+
+```console
+$ curl -H "Content-Type: application/json" \
+       -X POST \
+       -d '{"user": {"email": "dale.cooper@lessy.io"}}' \
+       https://lessy.io/api/users/activation_emails
+```
+
+```raw
+no content
+```
+
 ## `POST /api/users/authorizations`
 
 Authenticate a user and get a token valid for 1 month.

--- a/spec/requests/api/users/activation_emails_request_spec.rb
+++ b/spec/requests/api/users/activation_emails_request_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared_examples_for_failures'
+
+RSpec.describe Api::Users::ActivationEmailsController, type: :request do
+  describe 'POST #create' do
+    let!(:user) { create :user, user_trait, email: 'john@doe.com' }
+    let(:user_trait) { :inactive }
+    let(:payload) do
+      {
+        user: {
+          email: email,
+        },
+      }
+    end
+
+    subject { post api_users_activation_emails_path, params: payload, as: :json }
+
+    context 'with valid attributes' do
+      let(:email) { 'john@doe.com' }
+
+      it 'succeeds with no content' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'sends an email' do
+        expect { subject }
+          .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
+    context 'with missing attributes' do
+      let(:email) { nil }
+
+      before { subject }
+
+      it_behaves_like 'API errors', :unprocessable_entity, errors: [{
+        status: '422 Unprocessable Entity',
+        code: 'parameter_missing',
+        title: 'Parameter is missing',
+        detail: 'A parameter is missing or empty but it is required.',
+        source: { pointer: '/user/email' },
+      }]
+    end
+
+    context 'with an invalid email' do
+      let(:email) { 'steve@doe.com' }
+
+      before do
+        User.where(email: email).destroy_all
+        subject
+      end
+
+      it_behaves_like 'API errors', :not_found, errors: [{
+        status: '404 Not Found',
+        code: 'record_not_found',
+        title: 'Record not found',
+        detail: 'Record cannot be found, it has been deleted or you may not have access to it.',
+        source: { pointer: '/user' },
+      }]
+    end
+
+    context 'with a already active user' do
+      let(:user_trait) { :activated }
+      let(:email) { 'john@doe.com' }
+
+      it 'succeeds with no content' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'does not send an email' do
+        expect { subject }
+          .to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #184

Changes proposed in this pull request:

- Add buttons (dashboard + reset password pages) and endpoint to resend activation email

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [ ] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
