### PR TITLE
fix: Add workaround for resource loading failures

### DIFF
--- a/client/src/components/general/LoadingPage.vue
+++ b/client/src/components/general/LoadingPage.vue
@@ -4,9 +4,42 @@
 
     <ly-icon name="circle-o-notch" size="large" spin></ly-icon>
 
-    <p class="text-secondary">{{ $t('general.loadingPage.wait') }}</p>
+    <p v-if="!showReset" class="waiter text-secondary">
+      {{ $t('general.loadingPage.wait') }}
+    </p>
+    <div v-else class="reset-block">
+      <p class="text-secondary">
+        {{ $t('general.loadingPage.tooLong') }}
+      </p>
+      <ly-button @click="reset">
+        {{ $t('general.loadingPage.reset') }}
+      </ly-button>
+    </div>
   </app-page>
 </template>
+
+<script>
+  import auth from 'src/auth'
+
+  export default {
+    data () {
+      return {
+        showReset: false,
+      }
+    },
+
+    methods: {
+      reset () {
+        auth.logout()
+        window.location = '/login'
+      },
+    },
+
+    mounted () {
+      setTimeout(() => { this.showReset = true }, 10000)
+    },
+  }
+</script>
 
 <style lang="scss">
   .app-page-loading .app-layout-main {
@@ -22,8 +55,15 @@
                                         $ly-color-grey-10 83%,
                                         $ly-color-grey-20 83%);
 
-    > .text-secondary {
+    > .waiter,
+    > .reset-block {
       margin-top: 1.5rem;
+    }
+
+    .reset-block {
+      max-width: 30rem;
+
+      text-align: center;
     }
   }
 </style>

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -124,7 +124,9 @@ export default {
     },
 
     loadingPage: {
+      reset: 'Reset your session',
       title: 'Loading…',
+      tooLong: 'The loading takes too much time. It is sometimes useful to reset your session and re-login.',
       wait: '— Please sit and relax —',
     },
 

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -124,7 +124,9 @@ export default {
     },
 
     loadingPage: {
+      reset: 'Réinitialiser votre session',
       title: 'Chargement en cours…',
+      tooLong: 'Le chargement prend beaucoup de temps. Il est parfois utile de réinitialiser votre session et de vous reconnecter.',
       wait: '— Asseyez-vous et détendez-vous —',
     },
 


### PR DESCRIPTION
Changes proposed in this pull request:

Sometimes, the loading page is stuck because we weren't able to handle
correctly an error. It might happen after an upgrade of Lessy and the
only known solution is to re-login.

This commit adds a "reset" button to the loading page, and it appears
after 10 seconds of loading.

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
