### PR TITLE
fix: #337 Fix invalid auth token parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API changes
 
 - Provide `GET /api/users/me/features` endpoint
+- Accessing `GET /api/users/me` with an invalid user id now returns a `unauthorized` error
 
 ## Ara 2018-09-09
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,8 @@ class User < ApplicationRecord
 
   def self.find_by_authorization_token(token)
     decoded_token = JsonWebToken.decode(token)
-    return nil unless decoded_token
-    User.find decoded_token[:data][:user_id]
+    return nil unless decoded_token && decoded_token[:data]
+    User.find_by id: decoded_token[:data][:user_id]
   end
 
   def self.find_by_identifier!(identifier)

--- a/spec/requests/api/users_request_spec.rb
+++ b/spec/requests/api/users_request_spec.rb
@@ -149,15 +149,12 @@ RSpec.describe Api::UsersController, type: :request do
         subject
       end
 
-      it_behaves_like 'API errors', :not_found, {
-        errors: [{
-          status: '404 Not Found',
-          code: 'record_not_found',
-          title: 'Record not found',
-          detail: 'Record cannot be found, it has been deleted or you may not have access to it.',
-          source: { pointer: '/user' },
-        }],
-      }
+      it_behaves_like 'API errors', :unauthorized, errors: [{
+        status: '401 Unauthorized',
+        code: 'unauthorized',
+        title: 'Authorization is required',
+        detail: 'Resource you try to reach requires a valid Authorization token.',
+      }]
     end
 
     context 'with expired token' do


### PR DESCRIPTION
Closes #337

Changes proposed in this pull request:

- Handle old tokens that didn't have `data` payload
- Handle retrieving deleted user

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [ ] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
