### PR TITLE
add: Unplan task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,11 +23,22 @@ Rails/DynamicFindBy:
     - find_by_identifier!
     - find_by_sorcery_token!
 
+# This is bad but should be fixed with https://github.com/lessy-community/lessy/issues/84
+Rails/TimeZone:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 
+# This is bad but should be fixed with https://github.com/lessy-community/lessy/issues/84
+Style/DateTime:
+  Enabled: false
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
+
+Style/RedundantSelf:
+  Enabled: false
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Provide `GET /api/users/me/features` endpoint
 - Accessing `GET /api/users/me` with an invalid user id now returns a `unauthorized` error
 - Provide `DELETE /api/projects/:id` endpoint
+- `PUT /api/tasks/:id/state` endpoint now accepts `started` when task is planned
 
 ## Ara 2018-09-09
 

--- a/app/models/concerns/task_lifecycle.rb
+++ b/app/models/concerns/task_lifecycle.rb
@@ -47,6 +47,7 @@ module TaskLifecycle
 
     def on_replan(params)
       params[:finished_at] = nil
+      params[:started_at] = DateTime.now if self.started_at.nil?
       params[:planned_at] = DateTime.now
       params[:planned_count] = self.planned_count + 1
       params
@@ -85,6 +86,7 @@ module TaskLifecycle
     end
 
     def planned_task_is_valid
+      errors.add :started_at, :must_be_set, message: 'must be set when task is planned' if started_at.nil?
       errors.add :planned_at, :must_be_set, message: 'must be set when task is planned' if planned_at.nil?
       errors.add :finished_at, :cannot_be_set, message: 'cannot be set when task is planned' if finished_at.present?
       errors.add :abandoned_at, :cannot_be_set, message: 'cannot be set when task is planned' if abandoned_at.present?

--- a/app/models/concerns/task_lifecycle.rb
+++ b/app/models/concerns/task_lifecycle.rb
@@ -25,6 +25,7 @@ module TaskLifecycle
 
       # canceled transitions
       transition :replan, from: :finished, to: :planned
+      transition :unplan, from: :planned, to: :started
       transition :cancel, from: [:planned, :started], to: :newed
 
       # abandon
@@ -50,6 +51,11 @@ module TaskLifecycle
       params[:started_at] = DateTime.now if self.started_at.nil?
       params[:planned_at] = DateTime.now
       params[:planned_count] = self.planned_count + 1
+      params
+    end
+
+    def on_unplan(params)
+      params[:planned_at] = nil
       params
     end
 

--- a/client/src/api/tasks.js
+++ b/client/src/api/tasks.js
@@ -29,6 +29,12 @@ export default {
     })
   },
 
+  unplan (task) {
+    return put(`/api/tasks/${task.id}/state`, {
+      state: 'started',
+    })
+  },
+
   abandon (task) {
     return put(`/api/tasks/${task.id}/state`, {
       state: 'abandoned',

--- a/client/src/components/tasks/TaskItem.vue
+++ b/client/src/components/tasks/TaskItem.vue
@@ -37,6 +37,7 @@
 
       <template slot="menu">
         <ly-popover-item @click="() => { this.editMode = true }">{{ $t('tasks.item.edit') }}</ly-popover-item>
+        <ly-popover-item v-if="task.isForToday" @click="unplan">{{ $t('tasks.item.unplan') }}</ly-popover-item>
         <ly-popover-item @click="activeModal = 'abandon'">{{ $t('tasks.item.abandon') }}</ly-popover-item>
         <ly-popover-separator></ly-popover-separator>
         <ly-popover-item @click="activeModal = 'attach'">{{ $t('tasks.item.attachToProject') }}</ly-popover-item>
@@ -111,6 +112,10 @@
         } else {
           this.$store.dispatch('tasks/finish', { task })
         }
+      },
+
+      unplan () {
+        this.$store.dispatch('tasks/unplan', { task: this.task })
       },
     },
   }

--- a/client/src/components/tasks/TasksPlanner.vue
+++ b/client/src/components/tasks/TasksPlanner.vue
@@ -26,7 +26,7 @@
 
           <ly-list-item
             v-for="i in nbPlaceholders"
-            :key="i"
+            :key="`placeholder-${i}`"
             class="text-secondary"
           >
             {{ $tc(`tasks.planner.importantTaskPlaceholder.${i - 1}`, tasksTotalCount) }}

--- a/client/src/locales/en/messages.js
+++ b/client/src/locales/en/messages.js
@@ -402,6 +402,7 @@ export default {
       markAsDone: 'Mark as done',
       markAsUndone: 'Mark as undone',
       transformInProject: 'Transform into a project',
+      unplan: 'Unplan',
     },
 
     list: {

--- a/client/src/locales/fr/messages.js
+++ b/client/src/locales/fr/messages.js
@@ -397,6 +397,7 @@ export default {
       markAsDone: 'Marquer comme effectuée',
       markAsUndone: 'Marquer comme à faire',
       transformInProject: 'Transformer en projet',
+      unplan: 'Annuler la planification',
     },
 
     list: {

--- a/client/src/store/modules/tasks.js
+++ b/client/src/store/modules/tasks.js
@@ -183,6 +183,11 @@ const actions = {
                    .then((res) => commit('set', res.data))
   },
 
+  unplan ({ commit }, { task }) {
+    return tasksApi.unplan(task)
+                   .then((res) => commit('set', res.data))
+  },
+
   abandon ({ commit }, { task }) {
     return tasksApi.abandon(task)
                    .then((res) => commit('set', res.data))

--- a/docs/api/tasks.md
+++ b/docs/api/tasks.md
@@ -396,10 +396,10 @@ State follow this state's machine:
 ```ascii
 +------------------------------------------------------------------------------+
 |                                              plan          replan            |
-|           +--------------------------------------------+  +-----+            |
-|           |                                            |  |     |            |
-|  +--------+---+    start    +------------+   plan    +-v--+-----v-+          |
-|  | newed      +-------------> started    +-----------> planned    +-+        |
+|           +-----------------------+--------------------+  +-----+            |
+|           |                       |                    |  |     |            |
+|  +--------+---+    start    +-----+------+  unplan   +-v--+-----v-+          |
+|  | newed      +-------------> started    <-----------+ planned    +-+        |
 |  +--------^---+             +-----+------+           +----+----^--+ |        |
 |           |                       |                       |    |    |        |
 |           +-----------------------+-----------------------+    |    |finish  |
@@ -419,6 +419,7 @@ Also, following rules apply:
 - `planned_at` is set to now and `planned_count` is incremented by one on
   `plan` and `replan` actions
 - `finished_at` is set to nil on `replan` and to now on `finish`
+- `planned_at` is set to nil on `unplan`
 - `started_at` and `planned_at` are set to nil on `cancel`
 - `abandoned_at` is set to now on `abandon` action
 

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
 
     trait :planned do
       state { 'planned' }
+      started_at { 15.days.ago }
       planned_at { 15.days.from_now }
       finished_at { nil }
       abandoned_at { nil }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -197,9 +197,12 @@ RSpec.describe Task, type: :model do
         state: 'started',
       } }
 
-      it 'fails' do
-        expect { subject }
-          .to raise_error(Task::InvalidTransition, /Task cannot transition from 'planned' to 'started'/)
+      it 'sets task state to started' do
+        expect(subject.reload.state).to eq('started')
+      end
+
+      it 'sets planned_at attribute to nil' do
+        expect(subject.reload.planned_at).to be_nil
       end
     end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'create!' do
-    subject { Task.create! label: 'a task', state: 'planned', planned_count: 0, planned_at: DateTime.new(2017), user: user }
+    subject do
+      Task.create! label: 'a task',
+                   state: 'planned',
+                   planned_count: 0,
+                   started_at: DateTime.new(2016),
+                   planned_at: DateTime.new(2017),
+                   user: user
+    end
 
     it 'sets planned_count to 1 if planned_at is set' do
       expect(subject.planned_count).to eq 1
@@ -91,6 +98,11 @@ RSpec.describe Task, type: :model do
 
       it 'requires planned_at' do
         task.planned_at = nil
+        expect(task).to be_invalid
+      end
+
+      it 'requires started_at' do
+        task.started_at = nil
         expect(task).to be_invalid
       end
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Provide a "unplan" button on tasks planned for today

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
