### PR TITLE
fix: Hide the timezone form if user is inactive

### DIFF
--- a/client/src/components/profile/ProfilePage.vue
+++ b/client/src/components/profile/ProfilePage.vue
@@ -26,12 +26,12 @@
         <profile-password-new-form>
         </profile-password-new-form>
       </ly-section>
-    </template>
 
-    <ly-section :title="$t('profile.page.timeZone')">
-      <profile-time-zone-form :user="user">
-      </profile-time-zone-form>
-    </ly-section>
+      <ly-section :title="$t('profile.page.timeZone')">
+        <profile-time-zone-form :user="user">
+        </profile-time-zone-form>
+      </ly-section>
+    </template>
 
     <ly-section :title="$t('profile.page.language')">
       <profile-language-form>


### PR DESCRIPTION
Changes proposed in this pull request:

- Hide the timezone form if user is inactive

Pull request checklist:

- [x] branch is rebased on `master` \*
- [x] proper commit messages \*
- [x] proper coding style \*
- [x] code is properly tested
- [x] document API changes both in [technical documentation](https://github.com/lessy-community/lessy/tree/master/docs/api) and [changelog](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] [document migration notes](https://github.com/lessy-community/lessy/blob/master/CHANGELOG.md) (optional)
- [x] reviewer assigned (@marienfressinaud)

\* [Additional information in the documentation](https://github.com/lessy-community/lessy/tree/master/docs/pull_request.md).
